### PR TITLE
docs: add CLAUDE.md and folder READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Sprout docs state
+sprout-docs.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Stacks Facilitator is a stateless payment verification and settlement service for the Stacks blockchain, implementing the x402 protocol. Built in Go with Domain-Driven Design (DDD) architecture.
+
+## Commands
+
+```bash
+# Run tests
+go test ./... -v
+
+# Run tests with coverage
+go test ./... -cover
+
+# Run specific package tests
+go test ./internal/payment/domain/valueobject/... -v
+
+# Download dependencies
+go mod download
+
+# Build the binary (note: cmd/server/main.go needs to be created)
+go build -o server ./cmd/server
+
+# Run with Docker
+docker-compose up -d
+
+# Health check
+curl http://localhost:8080/health
+```
+
+## Architecture
+
+The codebase follows Domain-Driven Design with clear layer separation:
+
+### Layer Structure
+
+```
+internal/
+├── payment/                    # Payment bounded context
+│   ├── domain/                 # Core business logic (no external dependencies)
+│   │   ├── valueobject/        # Immutable value objects (Amount, Network, TokenType, etc.)
+│   │   └── service/            # Domain services (VerificationService)
+│   ├── application/command/    # Use cases/command handlers
+│   └── infrastructure/         # External concerns
+│       ├── blockchain/         # StacksClientAdapter
+│       └── http/               # Echo HTTP handlers and DTOs
+└── stacks/                     # Hiro API client implementation
+```
+
+### Key Design Patterns
+
+- **Value Objects** (`domain/valueobject/`): All blockchain primitives (TransactionID, StacksAddress, Amount, Network, TokenType) are immutable value objects with validation in constructors
+- **Command Handlers** (`application/command/`): VerifyPaymentHandler and SettlePaymentHandler implement the use cases
+- **Port/Adapter**: BlockchainClient and TransactionBroadcaster interfaces in command layer, implemented by StacksClientAdapter
+- **Dependency Injection**: Handlers receive dependencies through constructors
+
+### Data Flow
+
+1. HTTP request → `infrastructure/http/Handler` → parses DTO
+2. Handler creates Command struct → calls `application/command/*Handler`
+3. Command handler uses domain services and infrastructure adapters
+4. Results flow back through the same layers
+
+### Token Support
+
+- **STX**: Native token, uses `token_transfer` transaction type
+- **sBTC/USDCx**: SIP-010 tokens, uses `contract_call` with `transfer` function
+
+### Network Configuration
+
+Network selection determines Hiro API endpoint:
+- Mainnet: `https://api.mainnet.hiro.so`
+- Testnet: `https://api.testnet.hiro.so`
+
+## API Endpoints
+
+- `POST /api/v1/verify` - Verify existing blockchain transaction
+- `POST /api/v1/settle` - Broadcast signed transaction and wait for confirmation
+- `GET /health` - Health check
+
+## Testing Approach
+
+Tests use `github.com/stretchr/testify` for assertions. Each package has `*_test.go` files alongside the implementation. Mock interfaces are defined in command handlers for testing without blockchain access.

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,20 @@
+[← root](../README.md) · **internal**
+
+# Internal
+
+> Private application code following Domain-Driven Design architecture.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`payment/`](./payment/) | Payment bounded context (verify/settle use cases) |
+| [`stacks/`](./stacks/) | Hiro API client for Stacks blockchain |
+
+## Relationships
+
+- **Consumed by**: `cmd/server/main.go` (entry point)
+- **Structure**: DDD layers - domain, application, infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal) · Updated: 2025-01-07*

--- a/internal/payment/README.md
+++ b/internal/payment/README.md
@@ -1,0 +1,21 @@
+[← internal](../README.md) · **payment** · [root](../../README.md)
+
+# Payment
+
+> Bounded context for payment verification and settlement operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`domain/`](./domain/) | Core business logic and value objects |
+| [`application/`](./application/) | Use cases and command handlers |
+| [`infrastructure/`](./infrastructure/) | External adapters (HTTP, blockchain) |
+
+## Relationships
+
+- **Architecture**: Clean Architecture / Hexagonal - domain has no external dependencies
+- **Data flow**: HTTP → Application → Domain ← Infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment) · Updated: 2025-01-07*

--- a/internal/payment/application/README.md
+++ b/internal/payment/application/README.md
@@ -1,0 +1,19 @@
+[← payment](../README.md) · **application** · [root](../../../README.md)
+
+# Application
+
+> Use case orchestration layer implementing CQRS command pattern.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`command/`](./command/) | Command handlers for verify and settle operations |
+
+## Relationships
+
+- **Depends on**: `../domain/` for business logic and value objects
+- **Consumed by**: `../infrastructure/http/` handlers invoke commands
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/application) · Updated: 2025-01-07*

--- a/internal/payment/application/command/README.md
+++ b/internal/payment/application/command/README.md
@@ -1,0 +1,30 @@
+[← application](../README.md) · **command** · [root](../../../../README.md)
+
+# Command
+
+> Command handlers implementing payment verification and settlement use cases.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`verify_payment.go`](./verify_payment.go) | Verify existing blockchain transactions |
+| [`verify_payment_test.go`](./verify_payment_test.go) | Tests for verification handler |
+| [`settle_payment.go`](./settle_payment.go) | Broadcast and confirm payment transactions |
+| [`settle_payment_test.go`](./settle_payment_test.go) | Tests for settlement handler |
+
+## Key Types
+
+- `VerifyPaymentHandler` - Fetches tx, validates against criteria
+- `SettlePaymentHandler` - Broadcasts signed tx, waits for confirmation
+- `BlockchainClient` - Interface for tx fetching (port)
+- `TransactionBroadcaster` - Interface for tx broadcasting (port)
+
+## Relationships
+
+- **Depends on**: `../../domain/service/` for VerificationService
+- **Depends on**: `../../domain/valueobject/` for domain primitives
+- **Implemented by**: `../../infrastructure/blockchain/` adapters
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/application/command) · Updated: 2025-01-07*

--- a/internal/payment/domain/README.md
+++ b/internal/payment/domain/README.md
@@ -1,0 +1,20 @@
+[← payment](../README.md) · **domain** · [root](../../../README.md)
+
+# Domain
+
+> Core business logic with no external dependencies (pure Go).
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`valueobject/`](./valueobject/) | Immutable domain primitives with validation |
+| [`service/`](./service/) | Domain services for business operations |
+
+## Relationships
+
+- **Consumed by**: All other layers depend on domain types
+- **Principle**: Domain never imports from application or infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain) · Updated: 2025-01-07*

--- a/internal/payment/domain/service/README.md
+++ b/internal/payment/domain/service/README.md
@@ -1,0 +1,27 @@
+[← domain](../README.md) · **service** · [root](../../../../README.md)
+
+# Service
+
+> Domain services implementing core business operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`verification_service.go`](./verification_service.go) | Transaction validation against criteria |
+| [`verification_service_test.go`](./verification_service_test.go) | Tests for verification logic |
+
+## Key Types
+
+- `VerificationService` - Validates blockchain transactions
+- `BlockchainTransaction` - Domain representation of a tx
+- `VerificationCriteria` - Rules for validation (recipient, amount, etc.)
+- `VerificationResult` - Valid/invalid with error list
+
+## Relationships
+
+- **Depends on**: `../valueobject/` for domain primitives
+- **Consumed by**: `../../application/command/` handlers
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain/service) · Updated: 2025-01-07*

--- a/internal/payment/domain/valueobject/README.md
+++ b/internal/payment/domain/valueobject/README.md
@@ -1,0 +1,32 @@
+[← domain](../README.md) · **valueobject** · [root](../../../../README.md)
+
+# Value Object
+
+> Immutable domain primitives with validation-on-construction.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`amount.go`](./amount.go) | Token amounts in base units (microSTX, satoshis) |
+| [`network.go`](./network.go) | Stacks network (mainnet/testnet) with API URLs |
+| [`token_type.go`](./token_type.go) | Supported tokens (STX, sBTC, USDCx) |
+| [`stacks_address.go`](./stacks_address.go) | Validated Stacks addresses (ST.../SP...) |
+| [`transaction_id.go`](./transaction_id.go) | 64-char hex transaction IDs |
+| [`payment_status.go`](./payment_status.go) | Payment lifecycle states |
+
+## Design Pattern
+
+All value objects follow the same pattern:
+1. Private struct fields
+2. `New*()` constructor with validation
+3. `String()` for display
+4. Domain-specific methods (e.g., `IsMainnet()`, `IsNative()`)
+
+## Relationships
+
+- **Consumed by**: All domain and application code
+- **No dependencies**: Pure Go, no external imports
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain/valueobject) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/README.md
+++ b/internal/payment/infrastructure/README.md
@@ -1,0 +1,20 @@
+[← payment](../README.md) · **infrastructure** · [root](../../../README.md)
+
+# Infrastructure
+
+> External adapters implementing domain ports (HTTP, blockchain).
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`http/`](./http/) | Echo HTTP handlers and request/response DTOs |
+| [`blockchain/`](./blockchain/) | Stacks blockchain client adapter |
+
+## Relationships
+
+- **Implements**: Interfaces defined in `../application/command/`
+- **Depends on**: `../domain/` for value objects and services
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/blockchain/README.md
+++ b/internal/payment/infrastructure/blockchain/README.md
@@ -1,0 +1,27 @@
+[← infrastructure](../README.md) · **blockchain** · [root](../../../../README.md)
+
+# Blockchain
+
+> Adapter connecting domain layer to Stacks blockchain via Hiro API.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`stacks_client_adapter.go`](./stacks_client_adapter.go) | Implements BlockchainClient and TransactionBroadcaster |
+
+## Key Types
+
+- `StacksClientAdapter` - Wraps Stacks client for domain use
+  - `GetTransactionWithRetry()` - Fetch tx with retry logic
+  - `WaitForConfirmation()` - Poll until confirmed/failed
+  - `BroadcastTransaction()` - Submit signed tx to network
+
+## Relationships
+
+- **Implements**: `BlockchainClient`, `TransactionBroadcaster` from application layer
+- **Depends on**: `../../../stacks/` for low-level API calls
+- **Network routing**: Maintains separate mainnet/testnet clients
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure/blockchain) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/http/README.md
+++ b/internal/payment/infrastructure/http/README.md
@@ -1,0 +1,34 @@
+[← infrastructure](../README.md) · **http** · [root](../../../../README.md)
+
+# HTTP
+
+> Echo framework HTTP handlers exposing payment API endpoints.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`handler.go`](./handler.go) | HTTP handlers for verify, settle, health |
+| [`handler_test.go`](./handler_test.go) | Handler integration tests |
+| [`dto.go`](./dto.go) | Request/response data transfer objects |
+
+## Endpoints
+
+- `POST /api/v1/verify` - Verify existing transaction
+- `POST /api/v1/settle` - Broadcast and confirm transaction
+- `GET /health` - Service health check
+
+## Key Types
+
+- `Handler` - Main HTTP handler struct
+- `VerifyRequest/Response` - Verification DTOs
+- `SettleRequest/Response` - Settlement DTOs
+- `RegisterRoutes()` - Mounts all routes on Echo instance
+
+## Relationships
+
+- **Depends on**: `../../application/command/` handlers
+- **Framework**: labstack/echo/v4
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure/http) · Updated: 2025-01-07*

--- a/internal/stacks/README.md
+++ b/internal/stacks/README.md
@@ -1,0 +1,37 @@
+[← internal](../README.md) · **stacks** · [root](../../README.md)
+
+# Stacks
+
+> Low-level Hiro API client for Stacks blockchain operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`client.go`](./client.go) | HTTP client for Hiro Stacks API |
+| [`client_test.go`](./client_test.go) | Client tests with API response parsing |
+
+## Key Types
+
+- `Client` - HTTP client with configurable base URL
+- `TransactionResponse` - API response structure for `/extended/v1/tx/{id}`
+- `TokenTransferData` - STX native transfer fields
+- `ContractCallData` - SIP-010 contract call fields
+
+## API Endpoints Used
+
+- `GET /extended/v1/tx/{txid}` - Fetch transaction details
+- `POST /v2/transactions` - Broadcast signed transaction
+
+## Token Parsing
+
+- **STX**: Parsed from `token_transfer` field
+- **SIP-010** (sBTC, USDCx): Parsed from `contract_call.function_args`
+
+## Relationships
+
+- **Consumed by**: `../payment/infrastructure/blockchain/` adapter
+- **External**: Hiro API (mainnet/testnet)
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/stacks) · Updated: 2025-01-07*


### PR DESCRIPTION
## Summary

- Add CLAUDE.md for Claude Code guidance (build commands, architecture overview)
- Add navigable README.md files to all internal folders with breadcrumb navigation
- Add sprout-docs.json to .gitignore for documentation state tracking

## Folders Documented

- `internal/` - DDD architecture overview
- `internal/payment/` - Bounded context structure
- `internal/payment/application/command/` - Use case handlers
- `internal/payment/domain/service/` - Verification logic
- `internal/payment/domain/valueobject/` - Domain primitives
- `internal/payment/infrastructure/blockchain/` - Stacks adapter
- `internal/payment/infrastructure/http/` - Echo handlers
- `internal/stacks/` - Hiro API client

## Test plan

- [ ] Verify build passes
- [ ] Review README navigation links work correctly
- [ ] Confirm CLAUDE.md accurately describes the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)