### PR TITLE
feat: add Coinbase x402 compatibility adapter layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Sprout docs state
+sprout-docs.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Binaries
-server
+# Binaries (at root only, not cmd/server/)
+/server
 *.exe
 *.exe~
 *.dll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Stacks Facilitator is a stateless payment verification and settlement service for the Stacks blockchain, implementing the x402 protocol. Built in Go with Domain-Driven Design (DDD) architecture.
+
+## Commands
+
+```bash
+# Run tests
+go test ./... -v
+
+# Run tests with coverage
+go test ./... -cover
+
+# Run specific package tests
+go test ./internal/payment/domain/valueobject/... -v
+
+# Download dependencies
+go mod download
+
+# Build the binary (note: cmd/server/main.go needs to be created)
+go build -o server ./cmd/server
+
+# Run with Docker
+docker-compose up -d
+
+# Health check
+curl http://localhost:8080/health
+```
+
+## Architecture
+
+The codebase follows Domain-Driven Design with clear layer separation:
+
+### Layer Structure
+
+```
+internal/
+├── payment/                    # Payment bounded context
+│   ├── domain/                 # Core business logic (no external dependencies)
+│   │   ├── valueobject/        # Immutable value objects (Amount, Network, TokenType, etc.)
+│   │   └── service/            # Domain services (VerificationService)
+│   ├── application/command/    # Use cases/command handlers
+│   └── infrastructure/         # External concerns
+│       ├── blockchain/         # StacksClientAdapter
+│       └── http/               # Echo HTTP handlers and DTOs
+└── stacks/                     # Hiro API client implementation
+```
+
+### Key Design Patterns
+
+- **Value Objects** (`domain/valueobject/`): All blockchain primitives (TransactionID, StacksAddress, Amount, Network, TokenType) are immutable value objects with validation in constructors
+- **Command Handlers** (`application/command/`): VerifyPaymentHandler and SettlePaymentHandler implement the use cases
+- **Port/Adapter**: BlockchainClient and TransactionBroadcaster interfaces in command layer, implemented by StacksClientAdapter
+- **Dependency Injection**: Handlers receive dependencies through constructors
+
+### Data Flow
+
+1. HTTP request → `infrastructure/http/Handler` → parses DTO
+2. Handler creates Command struct → calls `application/command/*Handler`
+3. Command handler uses domain services and infrastructure adapters
+4. Results flow back through the same layers
+
+### Token Support
+
+- **STX**: Native token, uses `token_transfer` transaction type
+- **sBTC/USDCx**: SIP-010 tokens, uses `contract_call` with `transfer` function
+
+### Network Configuration
+
+Network selection determines Hiro API endpoint:
+- Mainnet: `https://api.mainnet.hiro.so`
+- Testnet: `https://api.testnet.hiro.so`
+
+## API Endpoints
+
+- `POST /api/v1/verify` - Verify existing blockchain transaction
+- `POST /api/v1/settle` - Broadcast signed transaction and wait for confirmation
+- `GET /health` - Health check
+
+## Testing Approach
+
+Tests use `github.com/stretchr/testify` for assertions. Each package has `*_test.go` files alongside the implementation. Mock interfaces are defined in command handlers for testing without blockchain access.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,122 @@ curl -X POST http://localhost:8080/api/v1/settle \
 
 ---
 
+## Coinbase x402 Compatible API
+
+These endpoints provide drop-in compatibility with Coinbase x402 clients, using the same request/response format.
+
+### Supported Kinds
+
+Returns the payment kinds this facilitator supports.
+
+```
+GET /supported
+```
+
+**Response:**
+```json
+{
+  "kinds": [
+    {"x402Version": 1, "scheme": "exact", "network": "stacks-mainnet"},
+    {"x402Version": 1, "scheme": "exact", "network": "stacks-testnet"}
+  ],
+  "extensions": [],
+  "signers": {}
+}
+```
+
+---
+
+### Verify Payment (Coinbase Format)
+
+Validates a signed transaction WITHOUT broadcasting. Checks authorization fields, recipient, amount, and sender balance.
+
+```
+POST /verify
+```
+
+**Request Body:**
+
+```json
+{
+  "paymentPayload": {
+    "x402Version": 1,
+    "scheme": "exact",
+    "network": "stacks-testnet",
+    "payload": {
+      "signedTransaction": "0x00000001...",
+      "authorization": {
+        "from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        "to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+        "value": "1000000"
+      }
+    }
+  },
+  "paymentRequirements": {
+    "scheme": "exact",
+    "network": "stacks-testnet",
+    "maxAmountRequired": "1000000",
+    "payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+  }
+}
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "isValid": true,
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+}
+```
+
+**Validation Failed Response (200 OK):**
+
+```json
+{
+  "isValid": false,
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  "invalidReason": "insufficient balance: has 500000, needs 1000000"
+}
+```
+
+---
+
+### Settle Payment (Coinbase Format)
+
+Broadcasts a signed transaction and waits for confirmation.
+
+```
+POST /settle
+```
+
+**Request Body:** Same format as `/verify`
+
+**Success Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  "transaction": "0xabcdef1234567890...",
+  "network": "stacks-testnet"
+}
+```
+
+**Failed Response (400 Bad Request):**
+
+```json
+{
+  "success": false,
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  "transaction": "0x...",
+  "network": "stacks-testnet",
+  "errorReason": "recipient mismatch"
+}
+```
+
+---
+
 ## Token Types
 
 | Token | Description | Transaction Type |
@@ -252,6 +368,7 @@ stacks-facilitator/
 │   │   └── infrastructure/            # External concerns
 │   │       ├── blockchain/            # Stacks client adapter
 │   │       └── http/                  # HTTP handlers
+│   │           └── coinbase/          # Coinbase x402 compatibility
 │   └── stacks/                        # Hiro API client
 ├── Dockerfile
 ├── docker-compose.yml

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/application/command"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/service"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/infrastructure/blockchain"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/infrastructure/http"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/infrastructure/http/coinbase"
+)
+
+func main() {
+	// Create Echo instance
+	e := echo.New()
+
+	// Middleware
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+	e.Use(middleware.CORS())
+
+	// Create infrastructure
+	stacksAdapter := blockchain.NewStacksClientAdapter()
+	verificationSvc := service.NewVerificationService()
+
+	// Create command handlers
+	verifyHandler := command.NewVerifyPaymentHandler(stacksAdapter, verificationSvc)
+	settleHandler := command.NewSettlePaymentHandler(stacksAdapter, verificationSvc)
+
+	// Register original API routes (/api/v1/*)
+	handler := http.NewHandler(verifyHandler, settleHandler)
+	handler.RegisterRoutes(e)
+
+	// Register Coinbase-compatible routes (/, /verify, /settle, /supported)
+	coinbaseHandler := coinbase.NewHandler(settleHandler, stacksAdapter)
+	coinbaseHandler.RegisterRoutes(e)
+
+	// Get port from environment or default
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	// Start server
+	log.Printf("Starting server on port %s", port)
+	if err := e.Start(":" + port); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,20 @@
+[← root](../README.md) · **internal**
+
+# Internal
+
+> Private application code following Domain-Driven Design architecture.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`payment/`](./payment/) | Payment bounded context (verify/settle use cases) |
+| [`stacks/`](./stacks/) | Hiro API client for Stacks blockchain |
+
+## Relationships
+
+- **Consumed by**: `cmd/server/main.go` (entry point)
+- **Structure**: DDD layers - domain, application, infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal) · Updated: 2025-01-07*

--- a/internal/payment/README.md
+++ b/internal/payment/README.md
@@ -1,0 +1,21 @@
+[← internal](../README.md) · **payment** · [root](../../README.md)
+
+# Payment
+
+> Bounded context for payment verification and settlement operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`domain/`](./domain/) | Core business logic and value objects |
+| [`application/`](./application/) | Use cases and command handlers |
+| [`infrastructure/`](./infrastructure/) | External adapters (HTTP, blockchain) |
+
+## Relationships
+
+- **Architecture**: Clean Architecture / Hexagonal - domain has no external dependencies
+- **Data flow**: HTTP → Application → Domain ← Infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment) · Updated: 2025-01-07*

--- a/internal/payment/application/README.md
+++ b/internal/payment/application/README.md
@@ -1,0 +1,19 @@
+[← payment](../README.md) · **application** · [root](../../../README.md)
+
+# Application
+
+> Use case orchestration layer implementing CQRS command pattern.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`command/`](./command/) | Command handlers for verify and settle operations |
+
+## Relationships
+
+- **Depends on**: `../domain/` for business logic and value objects
+- **Consumed by**: `../infrastructure/http/` handlers invoke commands
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/application) · Updated: 2025-01-07*

--- a/internal/payment/application/command/README.md
+++ b/internal/payment/application/command/README.md
@@ -1,0 +1,30 @@
+[← application](../README.md) · **command** · [root](../../../../README.md)
+
+# Command
+
+> Command handlers implementing payment verification and settlement use cases.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`verify_payment.go`](./verify_payment.go) | Verify existing blockchain transactions |
+| [`verify_payment_test.go`](./verify_payment_test.go) | Tests for verification handler |
+| [`settle_payment.go`](./settle_payment.go) | Broadcast and confirm payment transactions |
+| [`settle_payment_test.go`](./settle_payment_test.go) | Tests for settlement handler |
+
+## Key Types
+
+- `VerifyPaymentHandler` - Fetches tx, validates against criteria
+- `SettlePaymentHandler` - Broadcasts signed tx, waits for confirmation
+- `BlockchainClient` - Interface for tx fetching (port)
+- `TransactionBroadcaster` - Interface for tx broadcasting (port)
+
+## Relationships
+
+- **Depends on**: `../../domain/service/` for VerificationService
+- **Depends on**: `../../domain/valueobject/` for domain primitives
+- **Implemented by**: `../../infrastructure/blockchain/` adapters
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/application/command) · Updated: 2025-01-07*

--- a/internal/payment/domain/README.md
+++ b/internal/payment/domain/README.md
@@ -1,0 +1,20 @@
+[← payment](../README.md) · **domain** · [root](../../../README.md)
+
+# Domain
+
+> Core business logic with no external dependencies (pure Go).
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`valueobject/`](./valueobject/) | Immutable domain primitives with validation |
+| [`service/`](./service/) | Domain services for business operations |
+
+## Relationships
+
+- **Consumed by**: All other layers depend on domain types
+- **Principle**: Domain never imports from application or infrastructure
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain) · Updated: 2025-01-07*

--- a/internal/payment/domain/service/README.md
+++ b/internal/payment/domain/service/README.md
@@ -1,0 +1,27 @@
+[← domain](../README.md) · **service** · [root](../../../../README.md)
+
+# Service
+
+> Domain services implementing core business operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`verification_service.go`](./verification_service.go) | Transaction validation against criteria |
+| [`verification_service_test.go`](./verification_service_test.go) | Tests for verification logic |
+
+## Key Types
+
+- `VerificationService` - Validates blockchain transactions
+- `BlockchainTransaction` - Domain representation of a tx
+- `VerificationCriteria` - Rules for validation (recipient, amount, etc.)
+- `VerificationResult` - Valid/invalid with error list
+
+## Relationships
+
+- **Depends on**: `../valueobject/` for domain primitives
+- **Consumed by**: `../../application/command/` handlers
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain/service) · Updated: 2025-01-07*

--- a/internal/payment/domain/valueobject/README.md
+++ b/internal/payment/domain/valueobject/README.md
@@ -1,0 +1,32 @@
+[← domain](../README.md) · **valueobject** · [root](../../../../README.md)
+
+# Value Object
+
+> Immutable domain primitives with validation-on-construction.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`amount.go`](./amount.go) | Token amounts in base units (microSTX, satoshis) |
+| [`network.go`](./network.go) | Stacks network (mainnet/testnet) with API URLs |
+| [`token_type.go`](./token_type.go) | Supported tokens (STX, sBTC, USDCx) |
+| [`stacks_address.go`](./stacks_address.go) | Validated Stacks addresses (ST.../SP...) |
+| [`transaction_id.go`](./transaction_id.go) | 64-char hex transaction IDs |
+| [`payment_status.go`](./payment_status.go) | Payment lifecycle states |
+
+## Design Pattern
+
+All value objects follow the same pattern:
+1. Private struct fields
+2. `New*()` constructor with validation
+3. `String()` for display
+4. Domain-specific methods (e.g., `IsMainnet()`, `IsNative()`)
+
+## Relationships
+
+- **Consumed by**: All domain and application code
+- **No dependencies**: Pure Go, no external imports
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/domain/valueobject) · Updated: 2025-01-07*

--- a/internal/payment/domain/valueobject/stacks_address.go
+++ b/internal/payment/domain/valueobject/stacks_address.go
@@ -16,18 +16,21 @@ func NewStacksAddress(addr string) (StacksAddress, error) {
 		return StacksAddress{}, errors.New("address cannot be empty")
 	}
 
+	// Normalize to uppercase (Stacks addresses are canonically uppercase)
+	normalized := strings.ToUpper(addr)
+
 	// Validate prefix (ST for testnet, SP for mainnet, SM for mainnet multisig, SN for testnet multisig)
-	if !strings.HasPrefix(addr, "ST") && !strings.HasPrefix(addr, "SP") &&
-		!strings.HasPrefix(addr, "SM") && !strings.HasPrefix(addr, "SN") {
+	if !strings.HasPrefix(normalized, "ST") && !strings.HasPrefix(normalized, "SP") &&
+		!strings.HasPrefix(normalized, "SM") && !strings.HasPrefix(normalized, "SN") {
 		return StacksAddress{}, errors.New("invalid Stacks address prefix: must start with ST, SP, SM, or SN")
 	}
 
 	// Validate length (Stacks addresses are typically 41 characters)
-	if len(addr) < 30 || len(addr) > 50 {
+	if len(normalized) < 30 || len(normalized) > 50 {
 		return StacksAddress{}, errors.New("invalid Stacks address length")
 	}
 
-	return StacksAddress{value: addr}, nil
+	return StacksAddress{value: normalized}, nil
 }
 
 // String returns the address as a string

--- a/internal/payment/infrastructure/README.md
+++ b/internal/payment/infrastructure/README.md
@@ -1,0 +1,20 @@
+[← payment](../README.md) · **infrastructure** · [root](../../../README.md)
+
+# Infrastructure
+
+> External adapters implementing domain ports (HTTP, blockchain).
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`http/`](./http/) | Echo HTTP handlers and request/response DTOs |
+| [`blockchain/`](./blockchain/) | Stacks blockchain client adapter |
+
+## Relationships
+
+- **Implements**: Interfaces defined in `../application/command/`
+- **Depends on**: `../domain/` for value objects and services
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/blockchain/README.md
+++ b/internal/payment/infrastructure/blockchain/README.md
@@ -1,0 +1,27 @@
+[← infrastructure](../README.md) · **blockchain** · [root](../../../../README.md)
+
+# Blockchain
+
+> Adapter connecting domain layer to Stacks blockchain via Hiro API.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`stacks_client_adapter.go`](./stacks_client_adapter.go) | Implements BlockchainClient and TransactionBroadcaster |
+
+## Key Types
+
+- `StacksClientAdapter` - Wraps Stacks client for domain use
+  - `GetTransactionWithRetry()` - Fetch tx with retry logic
+  - `WaitForConfirmation()` - Poll until confirmed/failed
+  - `BroadcastTransaction()` - Submit signed tx to network
+
+## Relationships
+
+- **Implements**: `BlockchainClient`, `TransactionBroadcaster` from application layer
+- **Depends on**: `../../../stacks/` for low-level API calls
+- **Network routing**: Maintains separate mainnet/testnet clients
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure/blockchain) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/blockchain/stacks_client_adapter.go
+++ b/internal/payment/infrastructure/blockchain/stacks_client_adapter.go
@@ -87,3 +87,15 @@ func (a *StacksClientAdapter) getClientForNetwork(network valueobject.Network) *
 	}
 	return a.testnetClient
 }
+
+// GetSTXBalance returns the STX balance for an address on the specified network
+func (a *StacksClientAdapter) GetSTXBalance(ctx context.Context, address string, network valueobject.Network) (uint64, error) {
+	client := a.getClientForNetwork(network)
+	return client.GetSTXBalance(ctx, address)
+}
+
+// GetTokenBalance returns the token balance for an address on the specified network
+func (a *StacksClientAdapter) GetTokenBalance(ctx context.Context, address string, contractID string, network valueobject.Network) (uint64, error) {
+	client := a.getClientForNetwork(network)
+	return client.GetTokenBalance(ctx, address, contractID)
+}

--- a/internal/payment/infrastructure/http/README.md
+++ b/internal/payment/infrastructure/http/README.md
@@ -1,0 +1,34 @@
+[← infrastructure](../README.md) · **http** · [root](../../../../README.md)
+
+# HTTP
+
+> Echo framework HTTP handlers exposing payment API endpoints.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`handler.go`](./handler.go) | HTTP handlers for verify, settle, health |
+| [`handler_test.go`](./handler_test.go) | Handler integration tests |
+| [`dto.go`](./dto.go) | Request/response data transfer objects |
+
+## Endpoints
+
+- `POST /api/v1/verify` - Verify existing transaction
+- `POST /api/v1/settle` - Broadcast and confirm transaction
+- `GET /health` - Service health check
+
+## Key Types
+
+- `Handler` - Main HTTP handler struct
+- `VerifyRequest/Response` - Verification DTOs
+- `SettleRequest/Response` - Settlement DTOs
+- `RegisterRoutes()` - Mounts all routes on Echo instance
+
+## Relationships
+
+- **Depends on**: `../../application/command/` handlers
+- **Framework**: labstack/echo/v4
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/payment/infrastructure/http) · Updated: 2025-01-07*

--- a/internal/payment/infrastructure/http/coinbase/dto.go
+++ b/internal/payment/infrastructure/http/coinbase/dto.go
@@ -1,0 +1,91 @@
+// Package coinbase provides Coinbase x402 format compatibility adapter
+package coinbase
+
+// VerifyRequest represents a Coinbase-format verify request
+type VerifyRequest struct {
+	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
+	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
+}
+
+// SettleRequest represents a Coinbase-format settle request
+type SettleRequest struct {
+	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
+	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
+}
+
+// PaymentPayload represents the payment payload in Coinbase format
+type PaymentPayload struct {
+	X402Version int            `json:"x402Version"`
+	Scheme      string         `json:"scheme"`
+	Network     string         `json:"network"`
+	Payload     StacksPayload  `json:"payload"`
+}
+
+// StacksPayload contains Stacks-specific transaction data
+// Mirrors Coinbase EVM pattern: pre-parsed authorization fields + signed tx
+type StacksPayload struct {
+	SignedTransaction string        `json:"signedTransaction"`
+	Authorization     Authorization `json:"authorization"`
+}
+
+// Authorization contains pre-parsed transaction fields for validation
+// This mirrors Coinbase's EVM approach where clients provide parsed fields
+type Authorization struct {
+	From  string `json:"from"`  // Sender address (e.g., "SP..." or "ST...")
+	To    string `json:"to"`    // Recipient address
+	Value string `json:"value"` // Amount in base units (string for large numbers)
+}
+
+// PaymentRequirements specifies what the payment must satisfy
+type PaymentRequirements struct {
+	Scheme            string `json:"scheme"`
+	Network           string `json:"network"`
+	MaxAmountRequired string `json:"maxAmountRequired"`
+	Asset             string `json:"asset,omitempty"`
+	PayTo             string `json:"payTo"`
+	Resource          string `json:"resource,omitempty"`
+	Description       string `json:"description,omitempty"`
+}
+
+// VerifyResponse represents a Coinbase-format verify response
+type VerifyResponse struct {
+	IsValid       bool    `json:"isValid"`
+	Payer         string  `json:"payer"`
+	InvalidReason *string `json:"invalidReason,omitempty"`
+}
+
+// SettleResponse represents a Coinbase-format settle response
+type SettleResponse struct {
+	Success     bool    `json:"success"`
+	Payer       string  `json:"payer"`
+	Transaction string  `json:"transaction"`
+	Network     string  `json:"network"`
+	ErrorReason *string `json:"errorReason,omitempty"`
+}
+
+// SupportedKind represents a supported payment kind
+type SupportedKind struct {
+	X402Version int    `json:"x402Version"`
+	Scheme      string `json:"scheme"`
+	Network     string `json:"network"`
+}
+
+// SupportedResponse represents the /supported endpoint response
+type SupportedResponse struct {
+	Kinds      []SupportedKind   `json:"kinds"`
+	Extensions []string          `json:"extensions"`
+	Signers    map[string]string `json:"signers,omitempty"`
+}
+
+// ErrorCode constants for Coinbase-compatible error responses
+const (
+	ErrorCodeInsufficientFunds        = "insufficient_funds"
+	ErrorCodeInvalidNetwork           = "invalid_network"
+	ErrorCodeRecipientMismatch        = "invalid_exact_stacks_payload_recipient_mismatch"
+	ErrorCodeAmountTooLow             = "invalid_exact_stacks_payload_authorization_value"
+	ErrorCodeInvalidSignature         = "invalid_exact_stacks_payload_signature"
+	ErrorCodeMissingPayload           = "invalid_exact_stacks_payload_missing"
+	ErrorCodeMalformedPayload         = "invalid_exact_stacks_payload_malformed"
+	ErrorCodeBroadcastFailed          = "broadcast_failed"
+	ErrorCodeConfirmationFailed       = "confirmation_failed"
+)

--- a/internal/payment/infrastructure/http/coinbase/handler.go
+++ b/internal/payment/infrastructure/http/coinbase/handler.go
@@ -1,0 +1,249 @@
+package coinbase
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/application/command"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/valueobject"
+)
+
+// SettlePaymentHandler interface for settlement operations
+type SettlePaymentHandler interface {
+	Handle(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error)
+}
+
+// Handler handles Coinbase-format HTTP requests
+type Handler struct {
+	settleHandler SettlePaymentHandler
+	verifier      *PreSubmitVerifier
+}
+
+// NewHandler creates a new Coinbase-format Handler
+func NewHandler(settleHandler SettlePaymentHandler, balanceChecker BalanceChecker) *Handler {
+	return &Handler{
+		settleHandler: settleHandler,
+		verifier:      NewPreSubmitVerifier(balanceChecker),
+	}
+}
+
+// Verify handles POST /verify (Coinbase format)
+// Validates signed transaction WITHOUT broadcasting
+func (h *Handler) Verify(c echo.Context) error {
+	var req VerifyRequest
+	if err := c.Bind(&req); err != nil {
+		reason := "invalid request body: " + err.Error()
+		return c.JSON(http.StatusBadRequest, VerifyResponse{
+			IsValid:       false,
+			InvalidReason: &reason,
+		})
+	}
+
+	// Parse network
+	network, err := parseNetwork(req.PaymentPayload.Network)
+	if err != nil {
+		reason := ErrorCodeInvalidNetwork + ": " + err.Error()
+		return c.JSON(http.StatusBadRequest, VerifyResponse{
+			IsValid:       false,
+			InvalidReason: &reason,
+		})
+	}
+
+	// Parse token type from asset
+	tokenType, asset := parseAsset(req.PaymentRequirements.Asset, network)
+
+	// Parse minimum amount
+	minAmount, err := strconv.ParseUint(req.PaymentRequirements.MaxAmountRequired, 10, 64)
+	if err != nil {
+		reason := "invalid maxAmountRequired: " + err.Error()
+		return c.JSON(http.StatusBadRequest, VerifyResponse{
+			IsValid:       false,
+			InvalidReason: &reason,
+		})
+	}
+
+	// Build verification requirements
+	requirements := VerifyRequirements{
+		ExpectedRecipient: req.PaymentRequirements.PayTo,
+		MinAmount:         minAmount,
+		Network:           network,
+		TokenType:         tokenType,
+		Asset:             asset,
+	}
+
+	// Run pre-submit verification
+	result := h.verifier.Verify(c.Request().Context(), req.PaymentPayload.Payload, requirements)
+
+	response := VerifyResponse{
+		IsValid: result.Valid,
+		Payer:   result.Payer,
+	}
+
+	if !result.Valid && len(result.Errors) > 0 {
+		errorMsg := result.ErrorCode
+		if len(result.Errors) > 0 {
+			errorMsg = result.Errors[0]
+		}
+		response.InvalidReason = &errorMsg
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// Settle handles POST /settle (Coinbase format)
+// Broadcasts signed transaction and returns result
+func (h *Handler) Settle(c echo.Context) error {
+	var req SettleRequest
+	if err := c.Bind(&req); err != nil {
+		reason := "invalid request body: " + err.Error()
+		return c.JSON(http.StatusBadRequest, SettleResponse{
+			Success:     false,
+			ErrorReason: &reason,
+		})
+	}
+
+	// Parse network
+	network, err := parseNetwork(req.PaymentPayload.Network)
+	if err != nil {
+		reason := ErrorCodeInvalidNetwork + ": " + err.Error()
+		return c.JSON(http.StatusBadRequest, SettleResponse{
+			Success:     false,
+			ErrorReason: &reason,
+		})
+	}
+
+	// Parse token type
+	tokenType, _ := parseAsset(req.PaymentRequirements.Asset, network)
+
+	// Parse minimum amount
+	minAmount, err := strconv.ParseUint(req.PaymentRequirements.MaxAmountRequired, 10, 64)
+	if err != nil {
+		reason := "invalid maxAmountRequired: " + err.Error()
+		return c.JSON(http.StatusBadRequest, SettleResponse{
+			Success:     false,
+			ErrorReason: &reason,
+		})
+	}
+
+	// Extract sender from authorization if present
+	var expectedSender *string
+	if req.PaymentPayload.Payload.Authorization.From != "" {
+		sender := req.PaymentPayload.Payload.Authorization.From
+		expectedSender = &sender
+	}
+
+	// Build settle command for existing handler
+	cmd := command.SettlePaymentCommand{
+		SignedTransaction: req.PaymentPayload.Payload.SignedTransaction,
+		TokenType:         tokenType.String(),
+		ExpectedRecipient: req.PaymentRequirements.PayTo,
+		MinAmount:         minAmount,
+		ExpectedSender:    expectedSender,
+		Network:           network.String(),
+	}
+
+	// Execute settlement
+	result, err := h.settleHandler.Handle(c.Request().Context(), cmd)
+	if err != nil {
+		reason := ErrorCodeBroadcastFailed + ": " + err.Error()
+		return c.JSON(http.StatusInternalServerError, SettleResponse{
+			Success:     false,
+			Network:     formatNetworkForResponse(network),
+			ErrorReason: &reason,
+		})
+	}
+
+	response := SettleResponse{
+		Success:     result.Success,
+		Payer:       result.SenderAddress,
+		Transaction: result.TxID,
+		Network:     formatNetworkForResponse(network),
+	}
+
+	if !result.Success {
+		errorMsg := ErrorCodeConfirmationFailed
+		if len(result.Errors) > 0 {
+			errorMsg = result.Errors[0]
+		}
+		response.ErrorReason = &errorMsg
+	}
+
+	if result.Success {
+		return c.JSON(http.StatusOK, response)
+	}
+	return c.JSON(http.StatusBadRequest, response)
+}
+
+// Supported handles GET /supported
+// Returns supported payment kinds and capabilities
+func (h *Handler) Supported(c echo.Context) error {
+	response := SupportedResponse{
+		Kinds: []SupportedKind{
+			{
+				X402Version: 1,
+				Scheme:      "exact",
+				Network:     "stacks-mainnet",
+			},
+			{
+				X402Version: 1,
+				Scheme:      "exact",
+				Network:     "stacks-testnet",
+			},
+		},
+		Extensions: []string{},
+		Signers:    map[string]string{},
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+// RegisterRoutes registers the Coinbase-format routes at root level
+func (h *Handler) RegisterRoutes(e *echo.Echo) {
+	e.POST("/verify", h.Verify)
+	e.POST("/settle", h.Settle)
+	e.GET("/supported", h.Supported)
+}
+
+// parseNetwork converts Coinbase network format to internal Network
+// Coinbase format: "stacks-mainnet", "stacks-testnet"
+// Internal format: "mainnet", "testnet"
+func parseNetwork(network string) (valueobject.Network, error) {
+	normalized := strings.ToLower(network)
+
+	// Handle Coinbase format
+	if strings.HasPrefix(normalized, "stacks-") {
+		normalized = strings.TrimPrefix(normalized, "stacks-")
+	}
+
+	return valueobject.NewNetwork(normalized)
+}
+
+// formatNetworkForResponse converts internal network to Coinbase format
+func formatNetworkForResponse(network valueobject.Network) string {
+	return "stacks-" + network.String()
+}
+
+// parseAsset converts asset identifier to TokenType and contract ID
+// Returns (tokenType, contractID)
+func parseAsset(asset string, network valueobject.Network) (valueobject.TokenType, string) {
+	if asset == "" || strings.ToUpper(asset) == "STX" {
+		return valueobject.TokenSTX, ""
+	}
+
+	// Check for sBTC contract
+	if strings.Contains(strings.ToLower(asset), "sbtc") {
+		return valueobject.TokenSBTC, asset
+	}
+
+	// Check for USDCx contract
+	if strings.Contains(strings.ToLower(asset), "usdc") {
+		return valueobject.TokenUSDCX, asset
+	}
+
+	// Unknown asset - treat as SIP-010 token, default to STX behavior
+	// The contract ID will be used for balance checks
+	return valueobject.TokenSTX, asset
+}

--- a/internal/payment/infrastructure/http/coinbase/handler.go
+++ b/internal/payment/infrastructure/http/coinbase/handler.go
@@ -83,10 +83,7 @@ func (h *Handler) Verify(c echo.Context) error {
 	}
 
 	if !result.Valid && len(result.Errors) > 0 {
-		errorMsg := result.ErrorCode
-		if len(result.Errors) > 0 {
-			errorMsg = result.Errors[0]
-		}
+		errorMsg := result.Errors[0]
 		response.InvalidReason = &errorMsg
 	}
 
@@ -128,20 +125,13 @@ func (h *Handler) Settle(c echo.Context) error {
 		})
 	}
 
-	// Extract sender from authorization if present
-	var expectedSender *string
-	if req.PaymentPayload.Payload.Authorization.From != "" {
-		sender := req.PaymentPayload.Payload.Authorization.From
-		expectedSender = &sender
-	}
-
 	// Build settle command for existing handler
 	cmd := command.SettlePaymentCommand{
 		SignedTransaction: req.PaymentPayload.Payload.SignedTransaction,
 		TokenType:         tokenType.String(),
 		ExpectedRecipient: req.PaymentRequirements.PayTo,
 		MinAmount:         minAmount,
-		ExpectedSender:    expectedSender,
+		ExpectedSender:    stringPtrOrNil(req.PaymentPayload.Payload.Authorization.From),
 		Network:           network.String(),
 	}
 
@@ -246,4 +236,12 @@ func parseAsset(asset string, network valueobject.Network) (valueobject.TokenTyp
 	// Unknown asset - treat as SIP-010 token, default to STX behavior
 	// The contract ID will be used for balance checks
 	return valueobject.TokenSTX, asset
+}
+
+// stringPtrOrNil returns a pointer to s if non-empty, otherwise nil
+func stringPtrOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/internal/payment/infrastructure/http/coinbase/handler_test.go
+++ b/internal/payment/infrastructure/http/coinbase/handler_test.go
@@ -1,0 +1,684 @@
+package coinbase
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/application/command"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/valueobject"
+)
+
+// MockSettleHandler for testing
+type MockSettleHandler struct {
+	HandleFn func(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error)
+}
+
+func (m *MockSettleHandler) Handle(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error) {
+	return m.HandleFn(ctx, cmd)
+}
+
+// MockBalanceChecker for testing
+type MockBalanceChecker struct {
+	STXBalance   uint64
+	TokenBalance uint64
+	Error        error
+}
+
+func (m *MockBalanceChecker) GetSTXBalance(ctx context.Context, address string, network valueobject.Network) (uint64, error) {
+	if m.Error != nil {
+		return 0, m.Error
+	}
+	return m.STXBalance, nil
+}
+
+func (m *MockBalanceChecker) GetTokenBalance(ctx context.Context, address string, contractID string, network valueobject.Network) (uint64, error) {
+	if m.Error != nil {
+		return 0, m.Error
+	}
+	return m.TokenBalance, nil
+}
+
+func TestHandler_Supported(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 1000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/supported", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Supported(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response SupportedResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Len(t, response.Kinds, 2)
+	assert.Equal(t, "exact", response.Kinds[0].Scheme)
+	assert.Equal(t, "stacks-mainnet", response.Kinds[0].Network)
+	assert.Equal(t, 1, response.Kinds[0].X402Version)
+	assert.Equal(t, "stacks-testnet", response.Kinds[1].Network)
+}
+
+func TestHandler_Verify_Success(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.True(t, response.IsValid)
+	assert.Equal(t, "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7", response.Payer)
+	assert.Nil(t, response.InvalidReason)
+}
+
+func TestHandler_Verify_InsufficientBalance(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 500000} // Less than required
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, "insufficient balance")
+}
+
+func TestHandler_Verify_RecipientMismatch(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDTV2KJ3DKZE1B",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, "recipient mismatch")
+}
+
+func TestHandler_Verify_AmountTooLow(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "500000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, "amount too low")
+}
+
+func TestHandler_Verify_InvalidNetwork(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "invalid-network",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "invalid-network",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, ErrorCodeInvalidNetwork)
+}
+
+func TestHandler_Verify_InvalidRequest(t *testing.T) {
+	handler := NewHandler(nil, &MockBalanceChecker{})
+
+	e := echo.New()
+	reqBody := `{"invalid json`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_Settle_Success(t *testing.T) {
+	mockSettle := &MockSettleHandler{
+		HandleFn: func(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error) {
+			return command.SettlePaymentResult{
+				Success:          true,
+				TxID:             "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				SenderAddress:    "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+				RecipientAddress: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+				Amount:           1000000,
+				Fee:              180,
+				Status:           "success",
+				BlockHeight:      12345,
+				TokenType:        "STX",
+				Network:          "testnet",
+			}, nil
+		},
+	}
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(mockSettle, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/settle", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Settle(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response SettleResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7", response.Payer)
+	assert.Equal(t, "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", response.Transaction)
+	assert.Equal(t, "stacks-testnet", response.Network)
+	assert.Nil(t, response.ErrorReason)
+}
+
+func TestHandler_Settle_BroadcastError(t *testing.T) {
+	mockSettle := &MockSettleHandler{
+		HandleFn: func(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error) {
+			return command.SettlePaymentResult{}, errors.New("broadcast failed: network error")
+		},
+	}
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(mockSettle, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/settle", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Settle(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var response SettleResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.Success)
+	assert.NotNil(t, response.ErrorReason)
+	assert.Contains(t, *response.ErrorReason, ErrorCodeBroadcastFailed)
+}
+
+func TestHandler_Settle_VerificationFailed(t *testing.T) {
+	mockSettle := &MockSettleHandler{
+		HandleFn: func(ctx context.Context, cmd command.SettlePaymentCommand) (command.SettlePaymentResult, error) {
+			return command.SettlePaymentResult{
+				Success:          false,
+				TxID:             "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				SenderAddress:    "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+				RecipientAddress: "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDTV2KJ3DKZE1B",
+				Amount:           1000000,
+				Status:           "success",
+				Network:          "testnet",
+				Errors:           []string{"recipient mismatch"},
+			}, nil
+		},
+	}
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(mockSettle, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/settle", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Settle(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var response SettleResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.Success)
+	assert.NotNil(t, response.ErrorReason)
+	assert.Equal(t, "recipient mismatch", *response.ErrorReason)
+}
+
+func TestHandler_Settle_InvalidNetwork(t *testing.T) {
+	handler := NewHandler(nil, &MockBalanceChecker{})
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "invalid-network",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "invalid-network",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/settle", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Settle(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_Settle_InvalidRequest(t *testing.T) {
+	handler := NewHandler(nil, &MockBalanceChecker{})
+
+	e := echo.New()
+	reqBody := `{"invalid json`
+	req := httptest.NewRequest(http.MethodPost, "/settle", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Settle(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestParseNetwork(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"stacks-mainnet", "mainnet", false},
+		{"stacks-testnet", "testnet", false},
+		{"mainnet", "mainnet", false},
+		{"testnet", "testnet", false},
+		{"STACKS-MAINNET", "mainnet", false},
+		{"MAINNET", "mainnet", false},
+		{"invalid", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			network, err := parseNetwork(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, network.String())
+			}
+		})
+	}
+}
+
+func TestFormatNetworkForResponse(t *testing.T) {
+	tests := []struct {
+		input    valueobject.Network
+		expected string
+	}{
+		{valueobject.NetworkMainnet, "stacks-mainnet"},
+		{valueobject.NetworkTestnet, "stacks-testnet"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input.String(), func(t *testing.T) {
+			result := formatNetworkForResponse(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseAsset(t *testing.T) {
+	tests := []struct {
+		asset         string
+		expectedType  valueobject.TokenType
+		expectedAsset string
+	}{
+		{"", valueobject.TokenSTX, ""},
+		{"STX", valueobject.TokenSTX, ""},
+		{"stx", valueobject.TokenSTX, ""},
+		{"SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token", valueobject.TokenSBTC, "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token"},
+		{"SP123.usdc-token", valueobject.TokenUSDCX, "SP123.usdc-token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.asset, func(t *testing.T) {
+			tokenType, asset := parseAsset(tt.asset, valueobject.NetworkMainnet)
+			assert.Equal(t, tt.expectedType, tokenType)
+			assert.Equal(t, tt.expectedAsset, asset)
+		})
+	}
+}
+
+func TestHandler_Verify_MissingSignedTransaction(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "",
+				"authorization": {
+					"from": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, "signed transaction")
+}
+
+func TestHandler_Verify_MissingAuthorization(t *testing.T) {
+	mockBalance := &MockBalanceChecker{STXBalance: 2000000}
+	handler := NewHandler(nil, mockBalance)
+
+	e := echo.New()
+	reqBody := `{
+		"paymentPayload": {
+			"x402Version": 1,
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"payload": {
+				"signedTransaction": "0x00000001deadbeef",
+				"authorization": {
+					"from": "",
+					"to": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+					"value": "1000000"
+				}
+			}
+		},
+		"paymentRequirements": {
+			"scheme": "exact",
+			"network": "stacks-testnet",
+			"maxAmountRequired": "1000000",
+			"payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Verify(c)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response VerifyResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.False(t, response.IsValid)
+	assert.NotNil(t, response.InvalidReason)
+	assert.Contains(t, *response.InvalidReason, "sender address")
+}

--- a/internal/payment/infrastructure/http/coinbase/verify.go
+++ b/internal/payment/infrastructure/http/coinbase/verify.go
@@ -1,0 +1,162 @@
+package coinbase
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/valueobject"
+)
+
+// BalanceChecker defines the interface for checking account balances
+type BalanceChecker interface {
+	GetSTXBalance(ctx context.Context, address string, network valueobject.Network) (uint64, error)
+	GetTokenBalance(ctx context.Context, address string, contractID string, network valueobject.Network) (uint64, error)
+}
+
+// PreSubmitVerifier validates signed transactions before submission
+type PreSubmitVerifier struct {
+	balanceChecker BalanceChecker
+}
+
+// NewPreSubmitVerifier creates a new PreSubmitVerifier
+func NewPreSubmitVerifier(balanceChecker BalanceChecker) *PreSubmitVerifier {
+	return &PreSubmitVerifier{
+		balanceChecker: balanceChecker,
+	}
+}
+
+// VerifyRequirements contains the expected values for verification
+type VerifyRequirements struct {
+	ExpectedRecipient string
+	MinAmount         uint64
+	Network           valueobject.Network
+	TokenType         valueobject.TokenType
+	Asset             string // Contract ID for SIP-010 tokens
+}
+
+// PreSubmitResult contains the verification result
+type PreSubmitResult struct {
+	Valid     bool
+	Payer     string
+	ErrorCode string
+	Errors    []string
+}
+
+// Verify validates a signed transaction against requirements without broadcasting
+func (v *PreSubmitVerifier) Verify(ctx context.Context, payload StacksPayload, requirements VerifyRequirements) *PreSubmitResult {
+	result := &PreSubmitResult{
+		Valid: true,
+		Payer: payload.Authorization.From,
+	}
+
+	// Validate authorization fields are present
+	if payload.Authorization.From == "" {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, "missing sender address in authorization")
+		return result
+	}
+
+	if payload.Authorization.To == "" {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, "missing recipient address in authorization")
+		return result
+	}
+
+	if payload.Authorization.Value == "" {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, "missing value in authorization")
+		return result
+	}
+
+	// Parse and validate sender address
+	_, err := valueobject.NewStacksAddress(payload.Authorization.From)
+	if err != nil {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, fmt.Sprintf("invalid sender address: %s", err.Error()))
+		return result
+	}
+
+	// Parse and validate recipient address
+	_, err = valueobject.NewStacksAddress(payload.Authorization.To)
+	if err != nil {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, fmt.Sprintf("invalid recipient address: %s", err.Error()))
+		return result
+	}
+
+	// Validate recipient matches requirement
+	if !addressesMatch(payload.Authorization.To, requirements.ExpectedRecipient) {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeRecipientMismatch
+		result.Errors = append(result.Errors, fmt.Sprintf(
+			"recipient mismatch: got %s, expected %s",
+			payload.Authorization.To, requirements.ExpectedRecipient,
+		))
+		return result
+	}
+
+	// Parse and validate amount
+	amount, err := strconv.ParseUint(payload.Authorization.Value, 10, 64)
+	if err != nil {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMalformedPayload
+		result.Errors = append(result.Errors, fmt.Sprintf("invalid amount: %s", err.Error()))
+		return result
+	}
+
+	// Validate amount meets minimum
+	if amount < requirements.MinAmount {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeAmountTooLow
+		result.Errors = append(result.Errors, fmt.Sprintf(
+			"amount too low: got %d, minimum required %d",
+			amount, requirements.MinAmount,
+		))
+		return result
+	}
+
+	// Validate signed transaction is present
+	if payload.SignedTransaction == "" {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeMissingPayload
+		result.Errors = append(result.Errors, "missing signed transaction")
+		return result
+	}
+
+	// Check sender has sufficient balance
+	var balance uint64
+	if requirements.TokenType.IsNative() {
+		balance, err = v.balanceChecker.GetSTXBalance(ctx, payload.Authorization.From, requirements.Network)
+	} else {
+		balance, err = v.balanceChecker.GetTokenBalance(ctx, payload.Authorization.From, requirements.Asset, requirements.Network)
+	}
+
+	if err != nil {
+		// Balance check failed - we allow transaction to proceed but log the issue
+		// The blockchain will reject if balance is actually insufficient
+		result.Errors = append(result.Errors, fmt.Sprintf("balance check warning: %s", err.Error()))
+	} else if balance < amount {
+		result.Valid = false
+		result.ErrorCode = ErrorCodeInsufficientFunds
+		result.Errors = append(result.Errors, fmt.Sprintf(
+			"insufficient balance: has %d, needs %d",
+			balance, amount,
+		))
+		return result
+	}
+
+	return result
+}
+
+// addressesMatch compares two Stacks addresses for equality
+// Handles case-insensitivity for the prefix (SP/ST) and hash portion
+func addressesMatch(a, b string) bool {
+	return strings.EqualFold(a, b)
+}

--- a/internal/payment/infrastructure/http/coinbase/verify_test.go
+++ b/internal/payment/infrastructure/http/coinbase/verify_test.go
@@ -9,28 +9,8 @@ import (
 	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/valueobject"
 )
 
-type mockBalanceChecker struct {
-	stxBalance   uint64
-	tokenBalance uint64
-	err          error
-}
-
-func (m *mockBalanceChecker) GetSTXBalance(ctx context.Context, address string, network valueobject.Network) (uint64, error) {
-	if m.err != nil {
-		return 0, m.err
-	}
-	return m.stxBalance, nil
-}
-
-func (m *mockBalanceChecker) GetTokenBalance(ctx context.Context, address string, contractID string, network valueobject.Network) (uint64, error) {
-	if m.err != nil {
-		return 0, m.err
-	}
-	return m.tokenBalance, nil
-}
-
 func TestPreSubmitVerifier_Verify_Success(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -57,7 +37,7 @@ func TestPreSubmitVerifier_Verify_Success(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_MissingSender(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -84,7 +64,7 @@ func TestPreSubmitVerifier_Verify_MissingSender(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_MissingRecipient(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -111,7 +91,7 @@ func TestPreSubmitVerifier_Verify_MissingRecipient(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_MissingValue(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -138,7 +118,7 @@ func TestPreSubmitVerifier_Verify_MissingValue(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_InvalidSenderAddress(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -165,7 +145,7 @@ func TestPreSubmitVerifier_Verify_InvalidSenderAddress(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_RecipientMismatch(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -192,7 +172,7 @@ func TestPreSubmitVerifier_Verify_RecipientMismatch(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_AmountTooLow(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -219,7 +199,7 @@ func TestPreSubmitVerifier_Verify_AmountTooLow(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_MissingSignedTransaction(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -246,7 +226,7 @@ func TestPreSubmitVerifier_Verify_MissingSignedTransaction(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_InsufficientBalance(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 500000} // Less than required
+	checker := &MockBalanceChecker{STXBalance: 500000} // Less than required
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -273,7 +253,7 @@ func TestPreSubmitVerifier_Verify_InsufficientBalance(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_BalanceCheckError(t *testing.T) {
-	checker := &mockBalanceChecker{err: errors.New("network error")}
+	checker := &MockBalanceChecker{Error: errors.New("network error")}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -302,7 +282,7 @@ func TestPreSubmitVerifier_Verify_BalanceCheckError(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_TokenBalance(t *testing.T) {
-	checker := &mockBalanceChecker{tokenBalance: 2000000}
+	checker := &MockBalanceChecker{TokenBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{
@@ -329,7 +309,7 @@ func TestPreSubmitVerifier_Verify_TokenBalance(t *testing.T) {
 }
 
 func TestPreSubmitVerifier_Verify_RecipientCaseInsensitive(t *testing.T) {
-	checker := &mockBalanceChecker{stxBalance: 2000000}
+	checker := &MockBalanceChecker{STXBalance: 2000000}
 	verifier := NewPreSubmitVerifier(checker)
 
 	payload := StacksPayload{

--- a/internal/payment/infrastructure/http/coinbase/verify_test.go
+++ b/internal/payment/infrastructure/http/coinbase/verify_test.go
@@ -1,0 +1,354 @@
+package coinbase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/x402stacks/stacks-facilitator/internal/payment/domain/valueobject"
+)
+
+type mockBalanceChecker struct {
+	stxBalance   uint64
+	tokenBalance uint64
+	err          error
+}
+
+func (m *mockBalanceChecker) GetSTXBalance(ctx context.Context, address string, network valueobject.Network) (uint64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.stxBalance, nil
+}
+
+func (m *mockBalanceChecker) GetTokenBalance(ctx context.Context, address string, contractID string, network valueobject.Network) (uint64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.tokenBalance, nil
+}
+
+func TestPreSubmitVerifier_Verify_Success(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7", result.Payer)
+	assert.Empty(t, result.ErrorCode)
+}
+
+func TestPreSubmitVerifier_Verify_MissingSender(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeMalformedPayload, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "missing sender address")
+}
+
+func TestPreSubmitVerifier_Verify_MissingRecipient(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeMalformedPayload, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "missing recipient address")
+}
+
+func TestPreSubmitVerifier_Verify_MissingValue(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeMalformedPayload, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "missing value")
+}
+
+func TestPreSubmitVerifier_Verify_InvalidSenderAddress(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "invalid-address",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeMalformedPayload, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "invalid sender address")
+}
+
+func TestPreSubmitVerifier_Verify_RecipientMismatch(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDTV2KJ3DKZE1B",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeRecipientMismatch, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "recipient mismatch")
+}
+
+func TestPreSubmitVerifier_Verify_AmountTooLow(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "500000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeAmountTooLow, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "amount too low")
+}
+
+func TestPreSubmitVerifier_Verify_MissingSignedTransaction(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeMissingPayload, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "missing signed transaction")
+}
+
+func TestPreSubmitVerifier_Verify_InsufficientBalance(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 500000} // Less than required
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.False(t, result.Valid)
+	assert.Equal(t, ErrorCodeInsufficientFunds, result.ErrorCode)
+	assert.Contains(t, result.Errors[0], "insufficient balance")
+}
+
+func TestPreSubmitVerifier_Verify_BalanceCheckError(t *testing.T) {
+	checker := &mockBalanceChecker{err: errors.New("network error")}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	// Balance check errors should result in valid=true with a warning
+	// (blockchain will validate actual balance on broadcast)
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.True(t, result.Valid)
+	assert.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0], "balance check warning")
+}
+
+func TestPreSubmitVerifier_Verify_TokenBalance(t *testing.T) {
+	checker := &mockBalanceChecker{tokenBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSBTC,
+		Asset:             "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.True(t, result.Valid)
+	assert.Empty(t, result.ErrorCode)
+}
+
+func TestPreSubmitVerifier_Verify_RecipientCaseInsensitive(t *testing.T) {
+	checker := &mockBalanceChecker{stxBalance: 2000000}
+	verifier := NewPreSubmitVerifier(checker)
+
+	payload := StacksPayload{
+		SignedTransaction: "0x00000001deadbeef",
+		Authorization: Authorization{
+			From:  "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+			To:    "st1pqhqkv0rjxzfy1dgx8mnsnyve3vgzjsrtpgzgm", // lowercase
+			Value: "1000000",
+		},
+	}
+
+	requirements := VerifyRequirements{
+		ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM", // uppercase
+		MinAmount:         1000000,
+		Network:           valueobject.NetworkTestnet,
+		TokenType:         valueobject.TokenSTX,
+	}
+
+	result := verifier.Verify(context.Background(), payload, requirements)
+
+	assert.True(t, result.Valid)
+}

--- a/internal/stacks/README.md
+++ b/internal/stacks/README.md
@@ -1,0 +1,37 @@
+[← internal](../README.md) · **stacks** · [root](../../README.md)
+
+# Stacks
+
+> Low-level Hiro API client for Stacks blockchain operations.
+
+## Contents
+
+| Item | Purpose |
+|------|---------|
+| [`client.go`](./client.go) | HTTP client for Hiro Stacks API |
+| [`client_test.go`](./client_test.go) | Client tests with API response parsing |
+
+## Key Types
+
+- `Client` - HTTP client with configurable base URL
+- `TransactionResponse` - API response structure for `/extended/v1/tx/{id}`
+- `TokenTransferData` - STX native transfer fields
+- `ContractCallData` - SIP-010 contract call fields
+
+## API Endpoints Used
+
+- `GET /extended/v1/tx/{txid}` - Fetch transaction details
+- `POST /v2/transactions` - Broadcast signed transaction
+
+## Token Parsing
+
+- **STX**: Parsed from `token_transfer` field
+- **SIP-010** (sBTC, USDCx): Parsed from `contract_call.function_args`
+
+## Relationships
+
+- **Consumed by**: `../payment/infrastructure/blockchain/` adapter
+- **External**: Hiro API (mainnet/testnet)
+
+---
+*[View on main](https://github.com/x402stacks/stacks-facilitator/tree/main/internal/stacks) · Updated: 2025-01-07*

--- a/internal/stacks/client.go
+++ b/internal/stacks/client.go
@@ -296,3 +296,91 @@ func IsTransactionFailed(status string) bool {
 	}
 	return false
 }
+
+// AccountBalanceResponse represents the account balance API response
+type AccountBalanceResponse struct {
+	STX            STXBalance            `json:"stx"`
+	FungibleTokens map[string]TokenBalance `json:"fungible_tokens"`
+}
+
+// STXBalance represents STX balance info
+type STXBalance struct {
+	Balance       string `json:"balance"`
+	LockedBalance string `json:"locked"`
+}
+
+// TokenBalance represents a fungible token balance
+type TokenBalance struct {
+	Balance string `json:"balance"`
+}
+
+// GetSTXBalance returns the STX balance for an address
+func (c *Client) GetSTXBalance(ctx context.Context, address string) (uint64, error) {
+	url := fmt.Sprintf("%s/extended/v1/address/%s/stx", c.baseURL, address)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch balance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("API error: %s", string(body))
+	}
+
+	var balanceResp STXBalance
+	if err := json.NewDecoder(resp.Body).Decode(&balanceResp); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	balance, err := strconv.ParseUint(balanceResp.Balance, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance: %w", err)
+	}
+
+	return balance, nil
+}
+
+// GetTokenBalance returns the balance for a specific fungible token
+func (c *Client) GetTokenBalance(ctx context.Context, address string, contractID string) (uint64, error) {
+	url := fmt.Sprintf("%s/extended/v1/address/%s/balances", c.baseURL, address)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch balance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("API error: %s", string(body))
+	}
+
+	var balanceResp AccountBalanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&balanceResp); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	tokenBalance, exists := balanceResp.FungibleTokens[contractID]
+	if !exists {
+		return 0, nil // No balance for this token
+	}
+
+	balance, err := strconv.ParseUint(tokenBalance.Balance, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid balance: %w", err)
+	}
+
+	return balance, nil
+}


### PR DESCRIPTION
## Summary

Adds `/verify`, `/settle`, and `/supported` endpoints at root level with Coinbase x402 format compatibility, enabling drop-in support for Coinbase x402 clients.

- **New endpoints**: `GET /supported`, `POST /verify`, `POST /settle` (Coinbase format)
- **Pre-submission verification**: Validates transactions without broadcasting (balance check, recipient/amount validation)
- **Existing endpoints unchanged**: `/api/v1/verify` and `/api/v1/settle` work as before

### Key Insight: Verify Flow Difference

| Coinbase `/verify` | Original `/api/v1/verify` |
|-------------------|---------------------------|
| Validates signed tx WITHOUT broadcasting | Checks EXISTING on-chain tx by txId |
| Parses authorization fields, checks balance | Fetches tx from blockchain API |
| Returns `isValid` pre-submission | Returns validation of confirmed tx |

### Files Added
- `internal/payment/infrastructure/http/coinbase/` - DTOs, handler, pre-submit verifier
- `cmd/server/main.go` - Server entry point with route registration

### Files Modified
- `internal/stacks/client.go` - Added balance checking (STX + SIP-010 tokens)
- `internal/payment/infrastructure/blockchain/stacks_client_adapter.go` - Exposed balance methods
- `README.md` - API documentation for new endpoints

## Test plan

- [x] Run `go test ./... -v` - all tests pass
- [x] Run `go build -o server ./cmd/server` - builds successfully
- [x] Manual test `GET /supported` returns supported kinds
- [x] Manual test `POST /verify` validates without broadcasting
- [x] Manual test `POST /settle` broadcasts and confirms
- [x] Existing `/api/v1/*` endpoints still work

🤖 Generated with [Claude Code](https://claude.ai/code)