### PR TITLE
docs: improve README with comprehensive API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A stateless payment verification and settlement service for the Stacks blockchai
 
 ## Features
 
-- **Verify** existing blockchain transactions against specified criteria
+-**Verify** existing blockchain transactions against specified criteria
 - **Settle** payments by broadcasting signed transactions and confirming them on-chain
 - **Multi-token support**: STX, sBTC, USDCx
 - **Multi-network support**: Mainnet and Testnet
 - **Stateless**: No database required
 - **Retry logic**: Built-in retry mechanism for blockchain operations
+- **x402 v2 support**: Coinbase-compatible payment protocol endpoints
 
 ## Requirements
 
@@ -25,7 +26,7 @@ A stateless payment verification and settlement service for the Stacks blockchai
 docker-compose up -d
 
 # Check health
-curl http://localhost:8080/health
+curl http://localhost:8089/health
 ```
 
 ### Run Locally
@@ -42,25 +43,46 @@ go build -o server ./cmd/server
 ./server
 ```
 
-### Environment Variables
+## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `8080` | Server port |
+| `PORT` | `8080` | Server listening port |
+
+### Network Configuration
+
+The facilitator connects to Hiro API endpoints automatically based on the network specified in each request:
+
+| Network | API Endpoint |
+|---------|--------------|
+| `mainnet` | `https://api.mainnet.hiro.so` |
+| `testnet` | `https://api.testnet.hiro.so` |
+
+These endpoints are hardcoded and cannot be configured via environment variables.
+
+---
 
 ## API Reference
 
-### Base URLs
+### Base URL
 
-- **Mainnet API**: `https://api.mainnet.hiro.so`
-- **Testnet API**: `https://api.testnet.hiro.so`
+```
+http://localhost:8080
+```
+
+### Authentication
+
+No authentication required. The service is designed to run behind a reverse proxy or API gateway that handles authentication.
 
 ---
+
+## Endpoints
 
 ### Health Check
 
 Check if the service is running.
 
+**Request:**
 ```
 GET /health
 ```
@@ -72,21 +94,28 @@ GET /health
 }
 ```
 
+**Example:**
+```bash
+curl http://localhost:8080/health
+```
+
 ---
 
-### Verify Payment
+### Verify Payment (V1 - Legacy)
 
 Verify an existing blockchain transaction against specified criteria.
 
+**Request:**
 ```
 POST /api/v1/verify
+Content-Type: application/json
 ```
 
 **Request Body:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `tx_id` | string | Yes | Transaction ID (with or without `0x` prefix) |
+| `tx_id` | string | Yes | Transaction ID (with orwithout `0x` prefix) |
 | `expected_recipient` | string | Yes | Expected recipient Stacks address |
 | `min_amount` | integer | Yes | Minimum amount in base units (microSTX) |
 | `network` | string | Yes | Network: `mainnet` or `testnet` |
@@ -95,7 +124,6 @@ POST /api/v1/verify
 | `expected_memo` | string | No | Optional memo to validate |
 
 **Example Request:**
-
 ```bash
 curl -X POST http://localhost:8080/api/v1/verify \
   -H "Content-Type: application/json" \
@@ -109,7 +137,6 @@ curl -X POST http://localhost:8080/api/v1/verify \
 ```
 
 **Success Response (200 OK):**
-
 ```json
 {
   "valid": true,
@@ -119,7 +146,7 @@ curl -X POST http://localhost:8080/api/v1/verify \
   "amount": 1000000,
   "fee": 180,
   "nonce": 5,
-  "status": "confirmed",
+  "status": "success",
   "block_height": 12345,
   "token_type": "STX",
   "memo": "payment for service",
@@ -128,7 +155,6 @@ curl -X POST http://localhost:8080/api/v1/verify \
 ```
 
 **Validation Failed Response (200 OK):**
-
 ```json
 {
   "valid": false,
@@ -136,7 +162,7 @@ curl -X POST http://localhost:8080/api/v1/verify \
   "sender_address": "ST...",
   "recipient_address": "ST...",
   "amount": 500000,
-  "status": "confirmed",
+  "status": "success",
   "errors": [
     "insufficient amount: expected at least 1000000, got 500000"
   ]
@@ -145,12 +171,14 @@ curl -X POST http://localhost:8080/api/v1/verify \
 
 ---
 
-### Settle Payment
+### Settle Payment (V1 - Legacy)
 
 Broadcast a signed transaction and wait for confirmation.
 
+**Request:**
 ```
 POST /api/v1/settle
+Content-Type: application/json
 ```
 
 **Request Body:**
@@ -165,12 +193,11 @@ POST /api/v1/settle
 | `expected_sender` | string | No | Optional sender address to validate |
 
 **Example Request:**
-
 ```bash
 curl -X POST http://localhost:8080/api/v1/settle \
   -H "Content-Type: application/json" \
   -d '{
-    "signed_transaction": "0x00000001...",
+    "signed_transaction": "0x00000001038...",
     "expected_recipient": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
     "min_amount": 1000000,
     "network": "testnet"
@@ -178,7 +205,6 @@ curl -X POST http://localhost:8080/api/v1/settle \
 ```
 
 **Success Response (200 OK):**
-
 ```json
 {
   "success": true,
@@ -187,7 +213,7 @@ curl -X POST http://localhost:8080/api/v1/settle \
   "recipient_address": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
   "amount": 1000000,
   "fee": 180,
-  "status": "confirmed",
+  "status": "success",
   "block_height": 12346,
   "token_type": "STX",
   "network": "testnet"
@@ -195,16 +221,195 @@ curl -X POST http://localhost:8080/api/v1/settle \
 ```
 
 **Settlement Failed Response (400 Bad Request):**
-
 ```json
 {
   "success": false,
   "tx_id": "0x...",
-  "status": "confirmed",
+  "status": "success",
   "errors": [
     "recipient mismatch: expected ST1..., got ST2..."
   ]
 }
+```
+
+---
+
+### Verify Payment (V2 - x402 Coinbase-Compatible)
+
+Verify a payment using the x402 v2 protocol format (Coinbase-compatible).
+
+**Request:**
+```
+POST /verify
+Content-Type: application/json
+```
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `x402Version` | integer | No | Protocol version (default: 2) |
+| `paymentPayload` | object | Yes | Client's payment authorization |
+| `paymentRequirements` | object | Yes | Server's payment requirements |
+
+**PaymentRequirements Object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scheme` | string | Payment scheme: `exact` |
+| `network` | string | CAIP-2 network ID: `stacks:1` (mainnet) or `stacks:2147483648` (testnet) |
+| `amount` | string | Amount in microSTX |
+| `asset` | string | Asset identifier: `STX` or contract address |
+| `payTo` | string | Recipient Stacks address |
+| `maxTimeoutSeconds` | integer | Maximum payment timeout |
+| `extra` | object | Optional additional parameters |
+
+**Example Request:**
+```bash
+curl -X POST http://localhost:8080/verify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "x402Version": 2,
+    "paymentPayload": {
+      "x402Version": 2,"accepted": {
+        "scheme": "exact",
+        "network": "stacks:2147483648",
+        "amount": "1000000",
+        "asset": "STX",
+        "payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+      },
+      "payload": {
+        "transaction": "0x1234567890abcdef..."
+      }
+    },
+    "paymentRequirements": {
+      "scheme": "exact",
+      "network": "stacks:2147483648",
+      "amount": "1000000",
+      "asset": "STX",
+      "payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+    }
+  }'
+```
+
+**Success Response (200 OK):**
+```json
+{
+  "isValid": true
+}
+```
+
+**Invalid Payment Response (200 OK):**
+```json
+{
+  "isValid": false,
+  "invalidReason": "insufficient_amount",
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+}
+```
+
+---
+
+### Settle Payment (V2 - x402 Coinbase-Compatible)
+
+Settle a payment using the x402 v2 protocol format (Coinbase-compatible).
+
+**Request:**
+```
+POST /settle
+Content-Type: application/json
+```
+
+**Request Body:**
+
+Same structure as verify endpoint.
+
+**Example Request:**
+```bash
+curl -X POST http://localhost:8080/settle \
+  -H "Content-Type: application/json" \
+  -d '{
+    "x402Version": 2,
+    "paymentPayload": {
+      "x402Version": 2,
+      "accepted": {
+        "scheme": "exact",
+        "network": "stacks:2147483648",
+        "amount": "1000000",
+        "asset": "STX",
+        "payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+      },
+      "payload": {
+        "transaction": "0x00000001038..."
+      }
+    },
+    "paymentRequirements": {
+      "scheme": "exact",
+      "network": "stacks:2147483648",
+      "amount": "1000000",
+      "asset": "STX",
+      "payTo": "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+    }
+  }'
+```
+
+**Success Response (200 OK):**
+```json
+{
+  "success": true,
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  "transaction": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  "network": "stacks:2147483648"
+}
+```
+
+**Failed Response (400 Bad Request):**
+```json
+{
+  "success": false,
+  "errorReason": "broadcast_failed",
+  "payer": "ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  "transaction": "",
+  "network": "stacks:2147483648"
+}
+```
+
+---
+
+### Supported Payment Methods
+
+Get the list of supported payment methods and networks.
+
+**Request:**
+```
+GET /supported
+```
+
+**Response (200 OK):**
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "exact",
+      "network": "stacks:1"
+    },
+    {
+      "x402Version": 2,
+      "scheme": "exact",
+      "network": "stacks:2147483648"
+    }
+  ],
+  "extensions": [],
+  "signers": {
+    "stacks:*": []
+  }
+}
+```
+
+**Example:**
+```bash
+curl http://localhost:8080/supported
 ```
 
 ---
@@ -227,6 +432,17 @@ All amounts are in **base units**:
 | SBTC | satoshis | 1 sBTC = 100,000,000 satoshis |
 | USDCX | micro USDC | 1 USDC = 1,000,000 micro USDC |
 
+## Network Identifiers
+
+The V2 API uses CAIP-2 format for network identifiers:
+
+| Network | V1 Format | V2 Format (CAIP-2) |
+|---------|-----------|---------------------|
+| Mainnet | `mainnet` | `stacks:1` |
+| Testnet | `testnet` | `stacks:2147483648` |
+
+Both formats are accepted inV1 endpoints. V2 endpoints require CAIP-2 format.
+
 ## Verification Rules
 
 The service validates transactions against these criteria:
@@ -237,6 +453,37 @@ The service validates transactions against these criteria:
 4. **Amount**: Must be >= `min_amount`
 5. **Sender** (optional): If specified, must match exactly
 6. **Memo** (optional): If specified, must match exactly
+
+## Error Responses
+
+### V1 Error Format
+
+```json
+{
+  "error": "error_code",
+  "message": "Human readable error message"
+}
+```
+
+### V2 Error Format
+
+V1 endpoints return HTTP 200 with `valid: false`. Errors are in the `errors` array:
+
+```json
+{
+  "valid": false,
+  "errors": ["insufficient amount: expected 1000000, got 500000"]
+}
+```
+
+V2 endpoints return structured responses with `isValid` and `invalidReason`:
+
+```json
+{
+  "isValid": false,
+  "invalidReason": "insufficient_amount"
+}
+```
 
 ## Project Structure
 
@@ -269,6 +516,107 @@ go test ./... -cover
 
 # Run specific package tests
 go test ./internal/payment/domain/valueobject/... -v
+```
+
+## Usage Examples
+
+### JavaScript/TypeScript
+
+```typescript
+// Verify a payment (V1)
+async function verifyPayment(txId: string, recipient: string, amount: number) {
+  const response = await fetch('http://localhost:8080/api/v1/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      tx_id: txId,
+      expected_recipient: recipient,
+      min_amount: amount,
+      network: 'mainnet',
+      token_type: 'STX'
+    })
+  });
+  return response.json();
+}
+
+// Check health
+async function checkHealth() {
+  const response = await fetch('http://localhost:8080/health');
+  return response.json();
+}
+```
+
+### Python
+
+```python
+import requests
+
+# Verify a payment (V1)
+def verify_payment(tx_id: str, recipient: str, amount: int):
+    response = requests.post('http://localhost:8080/api/v1/verify', json={
+        'tx_id': tx_id,
+        'expected_recipient': recipient,
+        'min_amount': amount,
+        'network': 'mainnet',
+        'token_type': 'STX'
+    })
+    return response.json()
+
+# Settle a payment (V1)
+def settle_payment(signed_tx: str, recipient: str, amount: int):
+    response = requests.post('http://localhost:8080/api/v1/settle', json={
+        'signed_transaction': signed_tx,
+        'expected_recipient': recipient,
+        'min_amount': amount,
+        'network': 'mainnet'
+    })
+    return response.json()
+```
+
+### Go
+
+```go
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "net/http"
+)
+
+type VerifyRequest struct {
+    TxID              string `json:"tx_id"`
+    ExpectedRecipient string `json:"expected_recipient"`
+    MinAmount         uint64 `json:"min_amount"`
+    Network           string `json:"network"`
+    TokenType         string `json:"token_type"`
+}
+
+func main() {
+    req := VerifyRequest{
+        TxID:              "0x1234...",
+        ExpectedRecipient: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+        MinAmount:         1000000,
+        Network:           "mainnet",
+        TokenType:         "STX",
+    }
+    
+    body, _ := json.Marshal(req)
+    resp, err := http.Post(
+        "http://localhost:8080/api/v1/verify",
+        "application/json",
+        bytes.NewReader(body),
+    )
+    if err != nil {
+        panic(err)
+    }
+    defer resp.Body.Close()
+    
+    var result map[string]interface{}
+    json.NewDecoder(resp.Body).Decode(&result)
+    fmt.Printf("Result: %+v\n", result)
+}
 ```
 
 ## License


### PR DESCRIPTION
## Summary

This PR significantly improves the README documentation for the x402-stacks-facilitator repository:

### Changes

1. **Environment Variables Documentation**
   - Documents `PORT` environment variable with default value (8080)
   - Adds network configuration table explaining hardcoded Hiro API endpoints
   - Clarifies that network URLs cannot be configured via environment variables

2. **API Endpoint Documentation**
   - **V1 Endpoints** (Legacy): `/api/v1/verify`, `/api/v1/settle` - already documented but improved
   - **V2 Endpoints** (x402 Coinbase-compatible): `/verify`, `/settle`, `/supported` - **newly documented**
   - Added complete request/response examples for all endpoints
   - Added field descriptions and type information
   - Corrected status value from "confirmed" to "success" in examples

3. **Network Identifiers**
   - Added table showing V1 format (`mainnet`/`testnet`) vs V2 format (CAIP-2: `stacks:1`/`stacks:2147483648`)

4. **Usage Examples**
   - Added JavaScript/TypeScript example
   - Added Python example
   - Added Go example

5. **Error Documentation**
   - Documented V1 error response format
   - Documented V2 error response format

### Files Changed

- `README.md` - Comprehensive documentation update

### Testing

- Reviewed all code to identify environment variables (only `PORT` is used)
- Verified API endpoints match handler implementations
- Confirmed response structures match DTO definitions

---

Fixes documentation gaps identified in the codebase review.